### PR TITLE
Add appointment scheduling flow and modernize registration

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,48 @@
+import AppointmentCard from "@/components/cards/AppointmentCard"
+import { getRecentAppointments } from "@/lib/actions/appointment.actions"
+import { Appointment } from "@/types/appwrite.types"
+import Image from "next/image"
+
+const AdminPage = async () => {
+  const appointments = await getRecentAppointments()
+
+  return (
+    <div className="flex min-h-screen">
+      <section className="remove-scrollbar container my-auto">
+        <div className="sub-container space-y-10">
+          <header className="space-y-2">
+            <p className="text-14-regular text-dark-600 uppercase tracking-wide">
+              Admin Control Center
+            </p>
+            <h1 className="header">Appointments overview</h1>
+            <p className="text-dark-700">
+              Track patient requests, upcoming visits, and confirmations in real time.
+            </p>
+          </header>
+
+          <div className="space-y-6">
+            {appointments && appointments.length > 0 ? (
+              appointments.map((appointment: Appointment) => (
+                <AppointmentCard key={appointment.$id} appointment={appointment} />
+              ))
+            ) : (
+              <div className="rounded-2xl border border-dark-400 bg-dark-200 p-8 text-center text-dark-600">
+                No appointments yet. Encourage patients to request care from the home page.
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <Image
+        src="/assets/images/admin.png"
+        width={1000}
+        height={1000}
+        alt="admin"
+        className="side-img max-w-[45%]"
+      />
+    </div>
+  )
+}
+
+export default AdminPage

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
               © 2025 Spring2Life
             </p>
 
-            <Link href="/admin=true" className="text-green-500 transition-transform duration-300 ease-in-out transform hover:scale-110">
+            <Link href="/admin" className="text-green-500 transition-transform duration-300 ease-in-out transform hover:scale-110">
               Admin
             </Link>
           </div>

--- a/app/patients/[userId]/new-appointment/page.tsx
+++ b/app/patients/[userId]/new-appointment/page.tsx
@@ -1,0 +1,65 @@
+import AppointmentForm from "@/components/forms/AppointmentForm"
+import { getPatient } from "@/lib/actions/patient.actions"
+import Image from "next/image"
+import Link from "next/link"
+import { redirect } from "next/navigation"
+
+const NewAppointment = async ({ params, searchParams }: SearchParamProps) => {
+  const { userId } = await params
+  const patient = await getPatient(userId)
+
+  if (!patient) {
+    redirect(`/patients/${userId}/register`)
+  }
+
+  const success = searchParams?.success === "true"
+
+  return (
+    <div className="flex min-h-screen">
+      <section className="remove-scrollbar container my-auto">
+        <div className="sub-container max-w-[860px] space-y-8">
+          <Image
+            src="/spring2life.png"
+            width={1000}
+            height={1000}
+            alt="logo"
+            className="h-16 w-fit rounded-3xl"
+          />
+
+          {success && (
+            <div className="rounded-2xl border border-green-700 bg-green-500/10 p-4 text-green-100">
+              <p className="text-16-semibold">Appointment request received.</p>
+              <p className="text-14-regular text-green-200">
+                Our care team will confirm the schedule and send an SMS update shortly.
+              </p>
+            </div>
+          )}
+
+          <AppointmentForm userId={userId} patientId={patient.$id} patientName={patient.name} />
+
+          <div className="text-14-regular flex flex-col gap-2 text-dark-600">
+            <p className="text-dark-700">
+              Need to update your medical history?
+            </p>
+            <Link
+              href={`/patients/${userId}/register`}
+              className="text-green-500 underline"
+            >
+              Edit patient profile
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <Image
+        src="/assets/images/appointment-img.png"
+        width={1000}
+        height={1000}
+        alt="new appointment"
+        className="side-img max-w-[45%]"
+      />
+    </div>
+  )
+}
+
+export default NewAppointment

--- a/app/patients/[userId]/register/page.tsx
+++ b/app/patients/[userId]/register/page.tsx
@@ -1,48 +1,47 @@
 import RegisterForm from '@/components/forms/RegisterForm'
 import { getPatient, getUser } from '@/lib/actions/patient.actions'
 import Image from 'next/image'
-import Link from 'next/link'
-import React from 'react'
 import { redirect } from 'next/navigation'
 
 const Register = async ({ params }: SearchParamProps) => {
+  const { userId } = await params
+  const user = await getUser(userId)
+  const patient = await getPatient(userId)
 
-    const { userId } = await params;
-    const user = await getUser(userId);
-  const patient = await getPatient(userId);
+  if (!user) {
+    redirect('/')
+  }
 
-  if (patient) redirect(`/patients/${userId}/new-appointment`);
+  if (patient) {
+    redirect(`/patients/${userId}/new-appointment`)
+  }
 
-    return (
-        <div className="flex h-screen max-h-screen">
+  return (
+    <div className="flex h-screen max-h-screen">
+      <section className="remove-scrollbar container max-w-[860px] flex-1 flex-col py-10">
+        <div className="sub-container max-w-[496px]">
+          <Image
+            src="/spring2life.png"
+            width={10000}
+            height={10000}
+            alt="logo"
+            className="mb-12 h-20 w-fit rounded-3xl shadow-green-900 shadow-md transition-transform duration-300 ease-in-out transform hover:scale-110"
+          />
 
-            <section className="remove-scrollbar container max-w-[860px] flex-1 flex-col py-10">
-                <div className="sub-container max-w-[496px]"> 
-                <Image 
-                    src="/spring2life.png"
-                    width={10000}
-                    height={10000}
-                    alt="logo"
-                    className="mb-12 h-20 w-fit rounded-3xl shadow-green-900 shadow-md transition-transform duration-300 ease-in-out transform hover:scale-110"
-                />
-
-                <RegisterForm user={user}/>
-                        <p className="copyright py-12">
-                        © 2025 Spring2Life
-                        </p>
-
-                </div>
-            </section>
-
-            <Image 
-                src="/assets/images/register-img.png"
-                width={1000}
-                height={1000}
-                alt="patientForm"
-                className="side-img max-w-[390px]"
-            />
+          <RegisterForm user={user} />
+          <p className="copyright py-12">© 2025 Spring2Life</p>
         </div>
-    )
+      </section>
+
+      <Image
+        src="/assets/images/register-img.png"
+        width={1000}
+        height={1000}
+        alt="patientForm"
+        className="side-img max-w-[390px]"
+      />
+    </div>
+  )
 }
 
 export default Register

--- a/components/CustomFormField.tsx
+++ b/components/CustomFormField.tsx
@@ -2,14 +2,13 @@
 
 import {
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import { Control, Form } from "react-hook-form"
+import { Control, ControllerRenderProps, FieldValues } from "react-hook-form"
 import { FormFieldType } from "./forms/PatientForm"
 import Image from "next/image"
 import 'react-phone-number-input/style.css'
@@ -21,8 +20,8 @@ import { Select, SelectContent, SelectTrigger, SelectValue } from "./ui/select"
 import { Textarea } from "./ui/textarea"
 import { Checkbox } from "./ui/checkbox"
 
-interface CustomProps {
-    control : Control<any>,
+interface CustomProps<TFieldValues extends FieldValues = FieldValues> {
+    control : Control<TFieldValues>,
     fieldType: FormFieldType,
     name: string,
     label?: string,
@@ -33,11 +32,10 @@ interface CustomProps {
     dateFormat?: string,
     showTimeSelect?: boolean,
     children?: React.ReactNode,
-    renderSkeleton?: (field:any) => React.ReactNode,
+    renderSkeleton?: (field: ControllerRenderProps<TFieldValues, string>) => React.ReactNode,
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const RenderField = ({ field, props }: { field: any; props: CustomProps }) => {
+const RenderField = <TFieldValues extends FieldValues>({ field, props }: { field: ControllerRenderProps<TFieldValues, string>; props: CustomProps<TFieldValues> }) => {
 
     const { fieldType, iconSrc, iconAlt, placeholder, showTimeSelect, dateFormat, renderSkeleton } = props;
 
@@ -147,14 +145,15 @@ const RenderField = ({ field, props }: { field: any; props: CustomProps }) => {
     }
 }
 
-const CustomFormField = ( props: CustomProps) => {
+const CustomFormField = <TFieldValues extends FieldValues>( props: CustomProps<TFieldValues>) => {
 
     const { control, fieldType, name, label } = props;
 
     return (
         <FormField
             control={control}
-            name={name}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            name={name as any}
             render={({ field }) => (
                 <FormItem>
                     {fieldType !== FormFieldType.CHECKBOX && label && (

--- a/components/FileUploader.tsx
+++ b/components/FileUploader.tsx
@@ -2,7 +2,7 @@
 
 import { convertFileToUrl } from '@/lib/utils'
 import Image from 'next/image'
-import React, {useCallback} from 'react'
+import { useCallback } from 'react'
 import {useDropzone} from 'react-dropzone'
 
 type FileUploaderProps = {
@@ -12,10 +12,9 @@ type FileUploaderProps = {
 
 const FileUploader = ({ files, onChange }: FileUploaderProps) => {
   const onDrop = useCallback((acceptedFiles: File[]) => {
-    // Do something with the files
     onChange(acceptedFiles)
-  }, [])
-  const {getRootProps, getInputProps, isDragActive} = useDropzone({onDrop})
+  }, [onChange])
+  const {getRootProps, getInputProps} = useDropzone({onDrop, multiple: false})
 
   return (
     <div {...getRootProps()} className='file-upload'>

--- a/components/StatusBadge.tsx
+++ b/components/StatusBadge.tsx
@@ -1,0 +1,17 @@
+import Image from "next/image"
+import { StatusIcon } from "@/constants"
+
+const statusStyles: Record<Status, string> = {
+  pending: "bg-yellow-500/10 text-yellow-200",
+  scheduled: "bg-green-500/10 text-green-200",
+  cancelled: "bg-red-500/10 text-red-200",
+}
+
+const StatusBadge = ({ status }: { status: Status }) => (
+  <div className={`status-badge ${statusStyles[status]}`}>
+    <Image src={StatusIcon[status]} width={16} height={16} alt={status} />
+    <span className="text-14-medium capitalize">{status}</span>
+  </div>
+)
+
+export default StatusBadge

--- a/components/cards/AppointmentCard.tsx
+++ b/components/cards/AppointmentCard.tsx
@@ -1,0 +1,42 @@
+import { formatDateTime } from "@/lib/utils"
+import StatusBadge from "../StatusBadge"
+import { Appointment } from "@/types/appwrite.types"
+
+interface AppointmentCardProps {
+  appointment: Appointment
+}
+
+const AppointmentCard = ({ appointment }: AppointmentCardProps) => {
+  const { patient, primaryPhysician, reason, status, schedule } = appointment
+  const formatted = formatDateTime(schedule)
+
+  return (
+    <article className="flex flex-col gap-4 rounded-2xl border border-dark-400 bg-dark-300 p-6 shadow-lg">
+      <div className="flex-between gap-4 flex-wrap">
+        <div>
+          <p className="text-16-semibold text-white">{patient?.name}</p>
+          <p className="text-14-regular text-dark-600">{patient?.email}</p>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      <div className="flex flex-wrap gap-6 text-14-regular text-dark-600">
+        <div>
+          <p className="text-white">Physician</p>
+          <p>{primaryPhysician}</p>
+        </div>
+        <div>
+          <p className="text-white">Schedule</p>
+          <p>{formatted.dateTime}</p>
+        </div>
+      </div>
+
+      <div>
+        <p className="text-14-regular text-dark-600">Reason</p>
+        <p className="text-16-semibold text-white">{reason}</p>
+      </div>
+    </article>
+  )
+}
+
+export default AppointmentCard

--- a/components/forms/AppointmentForm.tsx
+++ b/components/forms/AppointmentForm.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { Form } from "@/components/ui/form"
+import CustomFormField from "../CustomFormField"
+import SubmitButton from "../SubmitButton"
+import { useState } from "react"
+import { CreateAppointmentSchema } from "@/lib/validation"
+import { FormFieldType } from "./PatientForm"
+import { Doctors } from "@/constants"
+import { SelectItem } from "../ui/select"
+import { createAppointment } from "@/lib/actions/appointment.actions"
+import { useRouter } from "next/navigation"
+
+interface AppointmentFormProps {
+  userId: string
+  patientId: string
+  patientName: string
+}
+
+const AppointmentForm = ({ userId, patientId, patientName }: AppointmentFormProps) => {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+
+  const form = useForm<z.infer<typeof CreateAppointmentSchema>>({
+    resolver: zodResolver(CreateAppointmentSchema),
+    defaultValues: {
+      primaryPhysician: "",
+      schedule: new Date(Date.now()),
+      reason: "",
+      note: "",
+    },
+  })
+
+  const onSubmit = async (values: z.infer<typeof CreateAppointmentSchema>) => {
+    setIsLoading(true)
+
+    try {
+      await createAppointment({
+        userId,
+        patientId,
+        primaryPhysician: values.primaryPhysician,
+        reason: values.reason,
+        schedule: values.schedule,
+        status: "pending",
+        note: values.note,
+      })
+
+      router.push(`/patients/${userId}/new-appointment?success=true`)
+      form.reset({
+        primaryPhysician: "",
+        schedule: new Date(Date.now()),
+        reason: "",
+        note: "",
+      })
+    } catch (error) {
+      console.error(error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <section className="space-y-1">
+          <p className="text-dark-700 text-sm uppercase tracking-wide">Schedule for</p>
+          <h2 className="header">{patientName}</h2>
+        </section>
+
+        <CustomFormField
+          fieldType={FormFieldType.SELECT}
+          control={form.control}
+          name="primaryPhysician"
+          label="Preferred Physician"
+          placeholder="Select a Physician"
+        >
+          {Doctors.map((doctor) => (
+            <SelectItem key={doctor.name} value={doctor.name}>
+              {doctor.name}
+            </SelectItem>
+          ))}
+        </CustomFormField>
+
+        <CustomFormField
+          fieldType={FormFieldType.DATE_PICKER}
+          control={form.control}
+          name="schedule"
+          label="Appointment Date"
+          showTimeSelect
+          dateFormat="MMM d, yyyy h:mm aa"
+        />
+
+        <CustomFormField
+          fieldType={FormFieldType.TEXTAREA}
+          control={form.control}
+          name="reason"
+          label="Reason for visit"
+          placeholder="Share what we should prepare for"
+        />
+
+        <CustomFormField
+          fieldType={FormFieldType.TEXTAREA}
+          control={form.control}
+          name="note"
+          label="Additional notes (optional)"
+          placeholder="Transportation needs, medication reminders, etc."
+        />
+
+        <SubmitButton isLoading={isLoading}>Book appointment</SubmitButton>
+      </form>
+    </Form>
+  )
+}
+
+export default AppointmentForm

--- a/components/forms/RegisterForm.tsx
+++ b/components/forms/RegisterForm.tsx
@@ -7,383 +7,331 @@ import { Form, FormControl } from "@/components/ui/form"
 import CustomFormField from "../CustomFormField"
 import SubmitButton from "../SubmitButton"
 import { useState } from "react"
-import { PatientFormValidation, UserFormValidation } from "@/lib/validation"
+import { PatientFormValidation } from "@/lib/validation"
 import { useRouter } from "next/navigation"
-import { createUser, registerPatient } from "@/lib/actions/patient.actions"
+import { registerPatient } from "@/lib/actions/patient.actions"
 import { FormFieldType } from "./PatientForm"
 import { RadioGroup, RadioGroupItem } from "../ui/radio-group"
-import { Doctors, GenderOptions, IdentificationTypes, PatientFormDefaultValues } from "@/constants"
+import {
+  Doctors,
+  GenderOptions,
+  IdentificationTypes,
+  PatientFormDefaultValues,
+} from "@/constants"
 import { Label } from "../ui/label"
 import { SelectItem } from "../ui/select"
 import Image from "next/image"
 import FileUploader from "../FileUploader"
 
+const RegisterForm = ({ user }: { user: User }) => {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
 
-    const RegisterForm = ({ user }: {user: User}) => {
+  const form = useForm<z.infer<typeof PatientFormValidation>>({
+    resolver: zodResolver(PatientFormValidation),
+    defaultValues: {
+      ...PatientFormDefaultValues,
+      name: user?.name || "",
+      email: user?.email || "",
+      phone: user?.phone || "",
+    },
+  })
 
-    const router = useRouter();
-    const [isLoading, setIsLoading] = useState(false);
+  async function onSubmit(values: z.infer<typeof PatientFormValidation>) {
+    setIsLoading(true)
 
-    // 1. Define your form.
-    const form = useForm<z.infer<typeof PatientFormValidation>>({
-        resolver: zodResolver(PatientFormValidation),
-        defaultValues: {
-        ...PatientFormDefaultValues,
-        name: "",
-        email: "",
-        phone: "",
-        },
-    })
+    let identificationFormData: FormData | undefined
 
-    // 2. Define a submit handler.
-    async function onSubmit(values: z.infer<typeof PatientFormValidation>) {
-        setIsLoading(true);
+    if (values.identificationDocument && values.identificationDocument.length > 0) {
+      const file = values.identificationDocument[0]
+      const blobFile = new Blob([file], { type: file.type })
 
-        let formData;
-
-        if (values.identificationDocument && values.identificationDocument.length > 0) {
-            const blobFile = new Blob([values.identificationDocument[0]], {
-                type: values.identificationDocument[0].type,
-            })
-
-            formData = new FormData();
-            formData.append('blobFile', blobFile);
-            formData.append('fileName', values.identificationDocument[0].name)
-        }
-
-        try {
-            const patientData = {
-                ...values,
-                userId: user.$id,
-                birthDate: new Date(values.birthDate),
-                IdentificationDocument: formData,
-            }
-            
-            // @ts-expect-error : allergies optional
-            const patient = await registerPatient(patientData);
-            
-            if (patient) router.push(`/patients/${user.$id}/new-appointment`)
-        } catch (error) {
-            console.log(error)
-        }
-        
-        try {
-        const userData = { name, email, phone }
-
-        const user = await createUser(userData);
-        
-        if(user) router.push(`/patients/${user.$id}/register`)
-        } catch (error) {
-        console.log(error)
-        }
+      identificationFormData = new FormData()
+      identificationFormData.append("blobFile", blobFile)
+      identificationFormData.append("fileName", file.name)
     }
 
-    return (
-        <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-12 flex-1">
-                <section className="space-y-4">
-                    <h1 className="header">
-                        Welcome to Spring2Life 🍃
-                    </h1>
-                    <p className="text-dark-700">
-                        Please complete the registration form to schedule your first appointment!
-                    </p>
-                </section>
+    try {
+      const patientData: RegisterUserParams = {
+        ...values,
+        userId: user.$id,
+        birthDate: new Date(values.birthDate),
+        identificationDocument: identificationFormData,
+      }
 
-                <section className="space-y-6">
-                    <div className="mb-9 space-y-1">
-                        <h2 className="sub-header">
-                            Personal Information
-                        </h2>                        
-                    </div>
+      const patient = await registerPatient(patientData)
+      if (patient) {
+        router.push(`/patients/${user.$id}/new-appointment`)
+      }
+    } catch (error) {
+      console.error(error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
 
-            {/* FULL NAME */}
-                    <CustomFormField
-                        fieldType={FormFieldType.INPUT}
-                        control={form.control}
-                        name="name"
-                        label="Full Name"
-                        placeholder="Nway Oo"
-                        iconSrc="/assets/icons/user.svg"
-                        iconAlt="user"
-                        />
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-12 flex-1">
+        <section className="space-y-4">
+          <h1 className="header">Welcome to Spring2Life 🍃</h1>
+          <p className="text-dark-700">
+            Please complete the registration form to schedule your first appointment!
+          </p>
+        </section>
 
-                    <div className="flex flex-col gap-6 xl:flex-row xl:justify-between">
-                    {/* EMAIL */}
-                        <CustomFormField
-                            fieldType={FormFieldType.INPUT}
-                            control={form.control}
-                            name="email"
-                            label="Email"
-                            placeholder="hi@spring2life.com"
-                            iconSrc="/assets/icons/email.svg"
-                            iconAlt="email"
-                        />
-                    {/* PHONE */}
-                        <CustomFormField
-                            fieldType={FormFieldType.PHONE_INPUT}
-                            control={form.control}
-                            name="phone"
-                            label="Phone Number"
-                            placeholder="(323)509-123"
-                        />
-                    </div>
+        <section className="space-y-6">
+          <div className="mb-1 space-y-1">
+            <h2 className="sub-header">Personal Information</h2>
+          </div>
 
-                    <div className="flex flex-col gap-6 xl:flex-row">
-                        {/* DATE OF BIRTH */}
-                        <CustomFormField
-                            fieldType={FormFieldType.DATE_PICKER}
-                            control={form.control}
-                            name="birthDate"
-                            label="Date of Birth"
-                        />
-                        {/* GENDER */}
-                        <CustomFormField
-                            fieldType={FormFieldType.SKELETON}
-                            control={form.control}
-                            name="gender"
-                            label="Gender"
-                            renderSkeleton={(field) => (
-                                <FormControl>
-                                    <RadioGroup className="flex h-11 gap-6 xl:justify-between" onValueChange={field.onChange} defaultValue={field.value}>
-                                        {GenderOptions.map((option, i) => {
-                                            const id = `gender-${i}`;
-                                            return (
-                                                <div key={id} className="flex items-center space-x-2">
-                                                    <RadioGroupItem value={option} id={id} title={option} />
-                                                    <Label htmlFor={id} className="cursor-pointer" title={option}>
-                                                        {option}
-                                                    </Label>
-                                                </div>
-                                            );
-                                        })}
-                                    </RadioGroup>
-                                </FormControl>
-                            )}
-                        />
-                    </div>
+          <CustomFormField
+            fieldType={FormFieldType.INPUT}
+            control={form.control}
+            name="name"
+            label="Full Name"
+            placeholder="Nway Oo"
+            iconSrc="/assets/icons/user.svg"
+            iconAlt="user"
+          />
 
-                    {/* ADDRESS */}
-                        <CustomFormField
-                            fieldType={FormFieldType.INPUT}
-                            control={form.control}
-                            name="address"
-                            label="Address"
-                            placeholder="No. 7, 36th Street, Mandalar Township, Mandalay"
-                        />
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <CustomFormField
+              fieldType={FormFieldType.INPUT}
+              control={form.control}
+              name="email"
+              label="Email"
+              placeholder="hi@spring2life.com"
+              iconSrc="/assets/icons/email.svg"
+              iconAlt="email"
+            />
+            <CustomFormField
+              fieldType={FormFieldType.PHONE_INPUT}
+              control={form.control}
+              name="phone"
+              label="Phone Number"
+              placeholder="(323)509-123"
+            />
+          </div>
 
-                    {/* OCCUPATION */}
-                        <CustomFormField
-                            fieldType={FormFieldType.INPUT}
-                            control={form.control}
-                            name="occupation"
-                            label="Occupation"
-                            placeholder="Self-Employed, Manager, Clerk..."
-                        />
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <CustomFormField
+              fieldType={FormFieldType.DATE_PICKER}
+              control={form.control}
+              name="birthDate"
+              label="Date of Birth"
+              placeholder="dd/mm/yyyy"
+            />
 
-                    <div className="flex flex-col gap-6 xl:flex-row">
-                    {/* EMERGENCY CONTACT */}
-                        <CustomFormField
-                            fieldType={FormFieldType.INPUT}
-                            control={form.control}
-                            name="emergencyContactName"
-                            label="Emergency Contact Name"
-                            placeholder="Next of Kin"
-                        />
-                        <CustomFormField
-                            fieldType={FormFieldType.PHONE_INPUT}
-                            control={form.control}
-                            name="emergencyContactNumber"
-                            label="Emergency Contact Number"
-                            placeholder="(323)509-123"
-                        />
-                    </div>
-                </section>
+            <CustomFormField
+              fieldType={FormFieldType.SKELETON}
+              control={form.control}
+              name="gender"
+              label="Gender"
+              renderSkeleton={(field) => (
+                <FormControl>
+                  <RadioGroup
+                    className="flex h-11 gap-6 rounded-md border border-dark-500 bg-dark-400 px-4"
+                    value={field.value}
+                    onValueChange={field.onChange}
+                  >
+                    {GenderOptions.map((option) => (
+                      <div key={option} className="flex items-center space-x-2">
+                        <RadioGroupItem value={option} id={option} />
+                        <Label htmlFor={option} className="text-white">
+                          {option}
+                        </Label>
+                      </div>
+                    ))}
+                  </RadioGroup>
+                </FormControl>
+              )}
+            />
+          </div>
 
-            {/* MEDICAL INFORMATION */}
-                <section className="space-y-6">
-                    <div className="mb-9 space-y-1">
-                        <h2 className="sub-header">
-                            Medical Information
-                        </h2>                        
-                    </div>
-                </section>
-            {/* PRIMARY PHYSICIAN */}
-                    <CustomFormField
-                        fieldType={FormFieldType.SELECT}
-                        control={form.control}
-                        name="primaryPhysician"
-                        label="Primary Physician"
-                        placeholder="Select a Physician"
-                    >
-                        {
-                            Doctors.map((doctor) => (
-                                <SelectItem
-                                    key={doctor.name}
-                                    value={doctor.name}
-                                >
-                                    <div className="flex cursor-pointer items-center gap-2">
-                                        <Image
-                                            src={doctor.image}
-                                            width={32}
-                                            height={32}
-                                            alt={doctor.name}
-                                            className="rounded-full border border-dark-500"
-                                        />
-                                        <p>
-                                            {doctor.name}
-                                        </p>
-                                    </div>
-                                </SelectItem>
-                            ))
-                        }
-                    </CustomFormField>
+          <CustomFormField
+            fieldType={FormFieldType.TEXTAREA}
+            control={form.control}
+            name="address"
+            label="Residential Address"
+            placeholder="123 Bogyoke Rd, Yangon"
+          />
 
-                <div className="flex flex-col gap-6 xl:flex-row">
-            {/* INSURANCE PROVIDER */}
-                    <CustomFormField
-                        fieldType={FormFieldType.INPUT}
-                        control={form.control}
-                        name="insuranceProvider"
-                        label="Insurance Provider"
-                        placeholder="Manu Life, AIG, Chubb, Dai-Ichi Life,Prudential..."
-                    />
+          <CustomFormField
+            fieldType={FormFieldType.INPUT}
+            control={form.control}
+            name="occupation"
+            label="Occupation"
+            placeholder="Nurse, Teacher, Relief Worker..."
+          />
 
-            {/* INSURANCE POLICY NUMBER */}
-                    <CustomFormField
-                        fieldType={FormFieldType.INPUT}
-                        control={form.control}
-                        name="insurancePolicyNumber"
-                        label="Insurance Policy Number"
-                        placeholder="CBA987654321..."
-                    />
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <CustomFormField
+              fieldType={FormFieldType.INPUT}
+              control={form.control}
+              name="emergencyContactName"
+              label="Emergency Contact Name"
+              placeholder="Thura Tun"
+            />
+            <CustomFormField
+              fieldType={FormFieldType.PHONE_INPUT}
+              control={form.control}
+              name="emergencyContactNumber"
+              label="Emergency Contact Number"
+              placeholder="(323)222-2222"
+            />
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <div className="mb-1 space-y-1">
+            <h2 className="sub-header">Medical Information</h2>
+          </div>
+
+          <CustomFormField
+            fieldType={FormFieldType.SELECT}
+            control={form.control}
+            name="primaryPhysician"
+            label="Primary Physician"
+            placeholder="Select a Physician"
+          >
+            {Doctors.map((doctor) => (
+              <SelectItem key={doctor.name} value={doctor.name}>
+                <div className="flex cursor-pointer items-center gap-2">
+                  <Image
+                    src={doctor.image}
+                    width={32}
+                    height={32}
+                    alt={doctor.name}
+                    className="rounded-full border border-dark-500"
+                  />
+                  <p>{doctor.name}</p>
                 </div>
+              </SelectItem>
+            ))}
+          </CustomFormField>
 
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <CustomFormField
+              fieldType={FormFieldType.INPUT}
+              control={form.control}
+              name="insuranceProvider"
+              label="Insurance Provider"
+              placeholder="ManuLife, AIG, Chubb..."
+            />
+            <CustomFormField
+              fieldType={FormFieldType.INPUT}
+              control={form.control}
+              name="insurancePolicyNumber"
+              label="Insurance Policy Number"
+              placeholder="CBA987654321"
+            />
+          </div>
 
-                <div className="flex flex-col gap-6 xl:flex-row">
-            {/* ALLERGIES */}
-                    <CustomFormField
-                        fieldType={FormFieldType.TEXTAREA}
-                        control={form.control}
-                        name="allergies"
-                        label="Allergies (if any)"
-                        placeholder="Peanuts, Gluten, Penicillin..."
-                    />
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <CustomFormField
+              fieldType={FormFieldType.TEXTAREA}
+              control={form.control}
+              name="allergies"
+              label="Allergies (if any)"
+              placeholder="Peanuts, Gluten, Penicillin..."
+            />
+            <CustomFormField
+              fieldType={FormFieldType.TEXTAREA}
+              control={form.control}
+              name="currentMedication"
+              label="Current Medication (if any)"
+              placeholder="Ibuprofen 200mg, Buspirone HCL 10mg..."
+            />
+          </div>
 
-            {/* CURRENT MEDICATIONS */}
-                    <CustomFormField
-                        fieldType={FormFieldType.TEXTAREA}
-                        control={form.control}
-                        name="currentMedication"
-                        label="Current Medication (if any)"
-                        placeholder="Ibuprofen 200mg, Buspirone HCL 10mg..."
-                    />
-                </div>
+          <div className="flex flex-col gap-6 xl:flex-row">
+            <CustomFormField
+              fieldType={FormFieldType.TEXTAREA}
+              control={form.control}
+              name="familyMedicalHistory"
+              label="Family Medical History"
+              placeholder="Diabetes, Hypertension..."
+            />
+            <CustomFormField
+              fieldType={FormFieldType.TEXTAREA}
+              control={form.control}
+              name="pastMedicalHistory"
+              label="Past Medical History"
+              placeholder="Appendectomy, Child Birth, Tonsillectomy..."
+            />
+          </div>
+        </section>
 
-                <div className="flex flex-col gap-6 xl:flex-row">
-            {/* FAMILY MEDICAL HISTORY */}
-                    <CustomFormField
-                        fieldType={FormFieldType.TEXTAREA}
-                        control={form.control}
-                        name="familyMedicalHistory"
-                        label="Family Medical History"
-                        placeholder="Paternal Diabetes Type2, Maternal High Cholestorl, Hypertension..."
-                    />
+        <section className="space-y-6">
+          <div className="mb-1 space-y-1">
+            <h2 className="sub-header">Identification &amp; Verification</h2>
+          </div>
 
-            {/* PAST MEDICAL HISTORY */}
-                    <CustomFormField
-                        fieldType={FormFieldType.TEXTAREA}
-                        control={form.control}
-                        name="pastMedicalHistory"
-                        label="Past Medical History"
-                        placeholder="Appendectomy, Child Birth, Tonsillectomy..."
-                    />
-                </div>
+          <CustomFormField
+            fieldType={FormFieldType.SELECT}
+            control={form.control}
+            name="identificationType"
+            label="Identification Type"
+            placeholder="Select an Identification Type"
+          >
+            {IdentificationTypes.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </CustomFormField>
 
-        {/* IDENTIFICATION & VERIFICATION */}
-                <section className="space-y-6">
-                    <div className="mb-9 space-y-1">
-                        <h2 className="sub-header">
-                            Identification & Verification
-                        </h2>                        
-                    </div>
-                </section>
+          <CustomFormField
+            fieldType={FormFieldType.INPUT}
+            control={form.control}
+            name="identificationNumber"
+            label="Identification Number"
+            placeholder="12/BHN(N)987654"
+          />
 
-        {/* ID TYPE */}
-                <CustomFormField
-                        fieldType={FormFieldType.SELECT}
-                        control={form.control}
-                        name="identificationType"
-                        label="Identification Type"
-                        placeholder="Select an Identification Type"
-                    >
-                        {
-                            IdentificationTypes.map((type) => (
-                                <SelectItem key={type} value={type}>
-                                    {type}
-                                </SelectItem>
-                            ))
-                        }
-                    </CustomFormField>
+          <CustomFormField
+            fieldType={FormFieldType.SKELETON}
+            control={form.control}
+            name="identificationDocument"
+            label="Scanned Copy of Identification Document"
+            renderSkeleton={(field) => (
+              <FormControl>
+                <FileUploader files={field.value} onChange={field.onChange} />
+              </FormControl>
+            )}
+          />
+        </section>
 
-        {/* ID NUMBER */}
-                    <CustomFormField
-                        fieldType={FormFieldType.INPUT}
-                        control={form.control}
-                        name="identificationNumber"
-                        label="Identification Number"
-                        placeholder="12/BHN(N)987654"
-                    />
+        <section className="space-y-6">
+          <div className="mb-1 space-y-1">
+            <h2 className="sub-header">Consent &amp; Privacy</h2>
+          </div>
 
-        {/* ID INPUT */}
-                    <CustomFormField
-                        fieldType={FormFieldType.SKELETON}
-                        control={form.control}
-                        name="identificationDocument"
-                        label="Scanned Copy of Identification Document"
-                        renderSkeleton={(field) => (
-                            <FormControl>
-                                <FileUploader
-                                    files={field.value}
-                                    onChange={field.onChange}
-                                />
-                            </FormControl>
-                        )}
-                    />
-        {/* CONSENT & PRIVACY */}
-                <section className="space-y-6">
-                    <div className="mb-9 space-y-1">
-                        <h2 className="sub-header">
-                            Consent & Privacy
-                        </h2>                        
-                    </div>
-                </section>
+          <CustomFormField
+            fieldType={FormFieldType.CHECKBOX}
+            control={form.control}
+            name="treatmentConsent"
+            label="I consent to treatment options provided via Spring2Life."
+          />
+          <CustomFormField
+            fieldType={FormFieldType.CHECKBOX}
+            control={form.control}
+            name="disclosureConsent"
+            label="I consent to disclosure of personal information for patient application."
+          />
+          <CustomFormField
+            fieldType={FormFieldType.CHECKBOX}
+            control={form.control}
+            name="privacyConsent"
+            label="I consent to the privacy policies of Spring2Life."
+          />
+        </section>
 
-                <CustomFormField 
-                    fieldType={FormFieldType.CHECKBOX}
-                    control={form.control}
-                    name='treatmentConsent'
-                    label="I consent to treatment options provided via Spring2Life."
-                />
-                <CustomFormField 
-                    fieldType={FormFieldType.CHECKBOX}
-                    control={form.control}
-                    name='disclosureConsent'
-                    label="I consent to disclosure of personal information for patient application."
-                />
-                <CustomFormField 
-                    fieldType={FormFieldType.CHECKBOX}
-                    control={form.control}
-                    name='privacyConsent'
-                    label="I consent to privacy policies of Spring2Life."
-                />
-
-        {/* SUBMIT */}
-                <SubmitButton isLoading={isLoading}>
-                    Register
-                </SubmitButton>
-            </form>
-        </Form>
-    )
+        <SubmitButton isLoading={isLoading}>Register</SubmitButton>
+      </form>
+    </Form>
+  )
 }
+
 export default RegisterForm

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,8 +1,7 @@
 export const GenderOptions = ["Male", "Female", "Other"];
 
 export const PatientFormDefaultValues = {
-  firstName: "",
-  lastName: "",
+  name: "",
   email: "",
   phone: "",
   birthDate: new Date(Date.now()),
@@ -20,7 +19,7 @@ export const PatientFormDefaultValues = {
   pastMedicalHistory: "",
   identificationType: "Birth Certificate",
   identificationNumber: "",
-  identificationDocument: [],
+  identificationDocument: [] as File[],
   treatmentConsent: false,
   disclosureConsent: false,
   privacyConsent: false,

--- a/lib/actions/appointment.actions.ts
+++ b/lib/actions/appointment.actions.ts
@@ -1,0 +1,137 @@
+"use server"
+
+import { Client, Databases, ID, Query, Models } from "node-appwrite"
+import {
+  API_KEY,
+  APPOINTMENT_COLLECTION_ID,
+  DATABASE_ID,
+  ENDPOINT,
+  PROJECT_ID,
+} from "../appwrite.config"
+import { parseStringify } from "../utils"
+import { getPatientById } from "./patient.actions"
+
+const client = new Client()
+  .setEndpoint(ENDPOINT!)
+  .setProject(PROJECT_ID!)
+  .setKey(API_KEY!)
+
+const databases = new Databases(client)
+
+type AppointmentRecord = Models.Document & {
+  patientId?: string
+  patient?: string
+}
+
+const withPatient = async (appointment: AppointmentRecord | null) => {
+  if (!appointment) return appointment
+
+  const patientId = appointment.patientId || appointment.patient
+  const patient = patientId ? await getPatientById(patientId) : null
+
+  return {
+    ...appointment,
+    patient,
+  }
+}
+
+export const createAppointment = async ({
+  userId,
+  patientId,
+  primaryPhysician,
+  reason,
+  schedule,
+  status,
+  note,
+}: CreateAppointmentParams) => {
+  try {
+    const appointment = await databases.createDocument(
+      DATABASE_ID!,
+      APPOINTMENT_COLLECTION_ID!,
+      ID.unique(),
+      {
+        userId,
+        patientId,
+        primaryPhysician,
+        reason,
+        schedule: schedule instanceof Date ? schedule.toISOString() : schedule,
+        status,
+        note,
+        cancellationReason: "",
+      }
+    )
+
+    const recordWithPatient = await withPatient(appointment)
+    return parseStringify(recordWithPatient)
+  } catch (error) {
+    console.error("Error creating appointment:", error)
+    throw error
+  }
+}
+
+export const getRecentAppointments = async () => {
+  try {
+    const appointments = await databases.listDocuments(
+      DATABASE_ID!,
+      APPOINTMENT_COLLECTION_ID!,
+      [Query.orderDesc("$createdAt"), Query.limit(25)]
+    )
+
+    const results = await Promise.all(
+      appointments.documents.map((appointment) => withPatient(appointment))
+    )
+
+    return parseStringify(results)
+  } catch (error) {
+    console.error("Error fetching appointments:", error)
+  }
+}
+
+export const getAppointmentsByUser = async (userId: string) => {
+  try {
+    const appointments = await databases.listDocuments(
+      DATABASE_ID!,
+      APPOINTMENT_COLLECTION_ID!,
+      [Query.equal("userId", [userId]), Query.orderDesc("$createdAt")]
+    )
+
+    const results = await Promise.all(
+      appointments.documents.map((appointment) => withPatient(appointment))
+    )
+
+    return parseStringify(results)
+  } catch (error) {
+    console.error("Error fetching user appointments:", error)
+  }
+}
+
+export const updateAppointment = async ({
+  appointmentId,
+  appointment,
+}: Pick<UpdateAppointmentParams, "appointmentId" | "appointment">) => {
+  try {
+    const payload = {
+      status: appointment.status,
+      primaryPhysician: appointment.primaryPhysician,
+      schedule:
+        appointment.schedule instanceof Date
+          ? appointment.schedule.toISOString()
+          : appointment.schedule,
+      note: appointment.note,
+      cancellationReason: appointment.cancellationReason ?? "",
+    }
+
+    const updated = await databases.updateDocument(
+      DATABASE_ID!,
+      APPOINTMENT_COLLECTION_ID!,
+      appointmentId,
+      payload
+    )
+
+    const recordWithPatient = await withPatient(updated)
+    return parseStringify(recordWithPatient)
+  } catch (error) {
+    console.error("Error updating appointment:", error)
+    throw error
+  }
+}

--- a/types/appwrite.types.ts
+++ b/types/appwrite.types.ts
@@ -20,17 +20,21 @@ export interface Patient extends Models.Document {
     pastMedicalHistory: string | undefined;
     identificationType: string | undefined;
     identificationNumber: string | undefined;
-    identificationDocument: FormData | undefined;
+    identificationDocumentId: string | null;
+    identificationDocumentUrl: string | null;
+    treatmentConsent: boolean;
+    disclosureConsent: boolean;
     privacyConsent: boolean;
 }
 
 export interface Appointment extends Models.Document {
-    patient: Patient;
-    schedule: Date;
+    patientId: string;
+    patient: Patient | null;
+    schedule: string | Date;
     status: Status;
     primaryPhysician: string;
     reason: string;
-    note: string;
+    note: string | undefined;
     userId: string;
     cancellationReason: string | null;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -33,12 +33,14 @@ declare interface RegisterUserParams extends CreateUserParams {
     identificationType: string | undefined;
     identificationNumber: string | undefined;
     identificationDocument: FormData | undefined;
+    treatmentConsent: boolean;
+    disclosureConsent: boolean;
     privacyConsent: boolean;
 }
 
 declare type CreateAppointmentParams = {
     userId: string;
-    patient: string;
+    patientId: string;
     primaryPhysician: string;
     reason: string;
     schedule: Date;


### PR DESCRIPTION
## Summary
- refresh the patient registration experience, fix Appwrite file uploads, and align form defaults with the current validation rules
- add appointment creation capabilities, including a dedicated booking form, server actions, and admin dashboard listings that mirror the reference implementation
- introduce reusable UI pieces (status badge, appointment card) plus new routing so patients can move from onboarding through scheduling without deprecated APIs

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d6ed318588325a21c904617b3879a)